### PR TITLE
Require securerandom to avoid uninitialized constant

### DIFF
--- a/lib/friendly_code.rb
+++ b/lib/friendly_code.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class FriendlyCode
   VERSION = '2.0.0'
 


### PR DESCRIPTION
This is really cool Matt! I finally got a chance to check it out. I can definitely think of some times this would come in handy. Thanks for sharing it on flowdock.

I ran into this little issue:

``` bash
$ gem install friendly_code
Fetching: friendly_code-2.0.0.gem (100%)
Successfully installed friendly_code-2.0.0
1 gem installed
$ irb
2.2.0 :001 > require "friendly_code"
 => true 
2.2.0 :002 > FriendlyCode.generate(10)
NameError: uninitialized constant FriendlyCode::SecureRandom
```

So I added `require 'securerandom'` at the top to ensure it was loaded.
